### PR TITLE
ccu: add CPU PLL clock register operation functions in the RCC peripheral.

### DIFF
--- a/src/ccu.rs
+++ b/src/ccu.rs
@@ -44,7 +44,93 @@ pub struct RegisterBlock {
 pub struct PllCpuControl(u32);
 
 impl PllCpuControl {
-    // p0 = (reg32 >> 16) & 0x03;
+    const PLL_ENABLE: u32 = 1 << 31;
+    const PLL_LDO_ENABLE: u32 = 1 << 30;
+    const LOCK_ENABLE: u32 = 1 << 29;
+    const LOCK: u32 = 1 << 28;
+    const PLL_OUTPUT_GATE: u32 = 1 << 27;
+    const PLL_N: u32 = 0xff << 8;
+    const PLL_M: u32 = 0x3 << 0;
+
+    /// Enable PLL.
+    #[inline]
+    pub const fn enable_pll(self) -> Self {
+        Self(self.0 | Self::PLL_ENABLE)
+    }
+    /// Disable PLL.
+    #[inline]
+    pub const fn disable_pll(self) -> Self {
+        Self(self.0 & !Self::PLL_ENABLE)
+    }
+    /// Get if PLL LDO is enabled.
+    #[inline]
+    pub const fn is_pll_ldo_enabled(self) -> bool {
+        self.0 & Self::PLL_LDO_ENABLE != 0
+    }
+    /// Enable PLL LDO.
+    #[inline]
+    pub const fn enable_pll_ldo(self) -> Self {
+        Self(self.0 | Self::PLL_LDO_ENABLE)
+    }
+    /// Disable PLL LDO.
+    #[inline]
+    pub const fn disable_pll_ldo(self) -> Self {
+        Self(self.0 & !Self::PLL_LDO_ENABLE)
+    }
+    /// Get if PLL lock is enabled.
+    #[inline]
+    pub const fn is_lock_enabled(self) -> bool {
+        self.0 & Self::LOCK_ENABLE != 0
+    }
+    /// Enable PLL lock.
+    #[inline]
+    pub const fn enable_lock(self) -> Self {
+        Self(self.0 | Self::LOCK_ENABLE)
+    }
+    /// Disable PLL lock.
+    #[inline]
+    pub const fn disable_lock(self) -> Self {
+        Self(self.0 & !Self::LOCK_ENABLE)
+    }
+    /// Get if PLL is locked.
+    #[inline]
+    pub const fn is_locked(self) -> bool {
+        self.0 & Self::LOCK != 0
+    }
+    /// Gate PLL output.
+    #[inline]
+    pub const fn gate_pll_output(self) -> Self {
+        Self(self.0 | Self::PLL_OUTPUT_GATE)
+    }
+    /// Ungate PLL output.
+    pub const fn ungate_pll_output(self) -> Self {
+        Self(self.0 & !Self::PLL_OUTPUT_GATE)
+    }
+    /// Get if PLL output is gated.
+    #[inline]
+    pub const fn is_pll_output_gated(self) -> bool {
+        self.0 & Self::PLL_OUTPUT_GATE != 0
+    }
+    /// Get PLL N factor.
+    #[inline]
+    pub const fn pll_n(self) -> u8 {
+        ((self.0 & Self::PLL_N) >> 8) as u8
+    }
+    /// Set PLL N factor.
+    #[inline]
+    pub const fn set_pll_n(self, val: u8) -> Self {
+        Self((self.0 & !Self::PLL_N) | ((val as u32) << 8))
+    }
+    /// Get PLL M factor.
+    #[inline]
+    pub const fn pll_m(self) -> u8 {
+        (self.0 & Self::PLL_M) as u8
+    }
+    /// Set PLL M factor.
+    #[inline]
+    pub const fn set_pll_m(self, val: u8) -> Self {
+        Self((self.0 & !Self::PLL_M) | val as u32)
+    }
 }
 
 /// DDR PLL Control register.


### PR DESCRIPTION
This pull request adds read/write functions for the `PllCpuControl`  register in RCC peripheral. We may acquire CPU frequency in this way: 

```rust
/// Get CPU frequency.
#[inline]
pub const fn cpu_frequency(self, osc24m: Hertz) -> Hertz {
    let n = (self.0 & Self::PLL_N) >> 8 as u8;
    let m = self.0 & Self::PLL_M as u8;
    osc24m * (m + 1) / (n + 1)
}
```