### PR TITLE
smhc: add SMHC registers, fields and unit test cases

### DIFF
--- a/src/ccu.rs
+++ b/src/ccu.rs
@@ -27,13 +27,22 @@ pub struct RegisterBlock {
     _reserved2: [u32; 311],
     /// 0x500 - CPU AXI Configuration register.
     pub cpu_axi_config: RW<CpuAxiConfig>,
-    _reserved3: [u32; 258],
+    _reserved3: [u32; 15],
+    /// 0x540 - MBUS Clock register.
+    pub mbus_clock: RW<MbusClock>,
+    _reserved4: [u32; 175],
+    /// 0x800 - DRAM Clock Register.
+    pub dram_clock: RW<DramClock>,
+    _reserved5: [u32; 2],
+    /// 0x80c - DRAM Bus Gating Reset register.
+    pub dram_bgr: RW<DramBusGating>,
+    _reserved6: [u32; 63],
     /// 0x90c - UART Bus Gating Reset register.
     pub uart_bgr: RW<UartBusGating>,
-    _reserved4: [u32; 12],
+    _reserved7: [u32; 12],
     /// 0x940..=0x944 - SPI0 Clock Register and SPI1 Clock Register.
     pub spi_clk: [RW<SpiClock>; 2],
-    _reserved5: [u32; 9],
+    _reserved8: [u32; 9],
     /// 0x96c - SPI Bus Gating Reset register.
     pub spi_bgr: RW<SpiBusGating>,
 }
@@ -471,6 +480,39 @@ impl CpuAxiConfig {
     }
 }
 
+/// MBUS Clock register.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct MbusClock(u32);
+
+impl MbusClock {
+    // TODO assert_reset, deassert_reset, is_reset_asserted
+}
+
+// TODO enum DramClockSource { PllDdr, PllAudio1, PllPeri2x, PllPeri800M }
+
+/// DRAM Clock Register.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct DramClock(u32);
+
+impl DramClock {
+    // TODO bit 31 - is_clock_unmasked, mask_clock, unmask_clock
+    // TODO bit 26:24 - clock_source, set_clock_source (DramClockSource)
+    // TODO bit 9:8 - factor_n, set_factor_n (FactorN)
+    // TODO bit 1:0 - factor_m, set_factor_m (u8)
+}
+
+/// Dram Bus Gating Reset register.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct DramBusGating(u32);
+
+impl DramBusGating {
+    // TODO bit 16: pub const fn assert_reset(self) -> Self, deassert_reset
+    // TODO bit 0: gate_mask, gate_pass
+}
+
 /// Clock divide factor N.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FactorN {
@@ -730,8 +772,17 @@ mod tests {
         assert_eq!(offset_of!(RegisterBlock, pll_ddr_control), 0x10);
         assert_eq!(offset_of!(RegisterBlock, pll_peri0_control), 0x20);
         assert_eq!(offset_of!(RegisterBlock, cpu_axi_config), 0x500);
+        assert_eq!(offset_of!(RegisterBlock, mbus_clock), 0x540);
+        assert_eq!(offset_of!(RegisterBlock, dram_clock), 0x800);
+        assert_eq!(offset_of!(RegisterBlock, dram_bgr), 0x80c);
         assert_eq!(offset_of!(RegisterBlock, uart_bgr), 0x90c);
         assert_eq!(offset_of!(RegisterBlock, spi_clk), 0x940);
         assert_eq!(offset_of!(RegisterBlock, spi_bgr), 0x96c);
     }
+    // TODO structure read/write function unit tests.
+    // Please refer to this link while implementing: https://github.com/rustsbi/bouffalo-hal/blob/6ee8ebf5fde184a68f4c3d5a1b7838dbbc7bfdd3/bouffalo-hal/src/i2c.rs#L902
+    // TODO #[test] fn struct_cpu_axi_config_functions()
+    // TODO struct_mbus_clock_functions
+    // TODO struct_dram_clock_functions
+    // TODO struct_dram_bgr_functions
 }

--- a/src/ccu.rs
+++ b/src/ccu.rs
@@ -230,12 +230,12 @@ impl PllDdrControl {
     /// Get PLL M1 factor.
     #[inline]
     pub const fn pll_m1(self) -> u8 {
-        (self.0 & Self::PLL_M1) as u8
+        ((self.0 & Self::PLL_M1) >> 1) as u8
     }
     /// Set PLL M1 factor.
     #[inline]
     pub const fn set_pll_m1(self, val: u8) -> Self {
-        Self((self.0 & !Self::PLL_M1) | val as u32)
+        Self((self.0 & !Self::PLL_M1) | ((val as u32) << 1))
     }
     /// Get PLL M0 factor.
     #[inline]
@@ -332,42 +332,42 @@ impl PllPeri0Control {
     /// Get PLL P1 factor.
     #[inline]
     pub const fn pll_p1(self) -> u8 {
-        (self.0 & Self::PLL_P1) as u8
+        ((self.0 & Self::PLL_P1) >> 20) as u8
     }
     /// Set PLL P1 factor.
     #[inline]
     pub const fn set_pll_p1(self, val: u8) -> Self {
-        Self((self.0 & !Self::PLL_P1) | val as u32)
+        Self((self.0 & !Self::PLL_P1) | ((val as u32) << 20))
     }
     /// Get PLL P0 factor.
     #[inline]
     pub const fn pll_p0(self) -> u8 {
-        (self.0 & Self::PLL_P0) as u8
+        ((self.0 & Self::PLL_P0) >> 16) as u8
     }
     /// Set PLL P0 factor.
     #[inline]
     pub const fn set_pll_p0(self, val: u8) -> Self {
-        Self((self.0 & !Self::PLL_P0) | val as u32)
+        Self((self.0 & !Self::PLL_P0) | ((val as u32) << 16))
     }
     /// Get PLL N factor.
     #[inline]
     pub const fn pll_n(self) -> u8 {
-        (self.0 & Self::PLL_N) as u8
+        ((self.0 & Self::PLL_N) >> 8) as u8
     }
     /// Set PLL N factor.
     #[inline]
     pub const fn set_pll_n(self, val: u8) -> Self {
-        Self((self.0 & !Self::PLL_N) | val as u32)
+        Self((self.0 & !Self::PLL_N) | ((val as u32) << 8))
     }
     /// Get PLL M factor.
     #[inline]
     pub const fn pll_m(self) -> u8 {
-        ((self.0 & Self::PLL_M) >> 8) as u8
+        ((self.0 & Self::PLL_M) >> 1) as u8
     }
     /// Set PLL M factor.
     #[inline]
     pub const fn set_pll_m(self, val: u8) -> Self {
-        Self((self.0 & !Self::PLL_M) | ((val as u32) << 8))
+        Self((self.0 & !Self::PLL_M) | ((val as u32) << 1))
     }
 }
 
@@ -447,7 +447,7 @@ impl CpuAxiConfig {
             FactorP::P2 => 1,
             FactorP::P4 => 2,
         };
-        Self((self.0 & !Self::FACTOR_N) | (val << 8))
+        Self((self.0 & !Self::FACTOR_P) | (val << 16))
     }
     /// Get AXI CPU clock divide factor N.
     #[inline]

--- a/src/ccu.rs
+++ b/src/ccu.rs
@@ -102,18 +102,18 @@ impl PllCpuControl {
     pub const fn is_locked(self) -> bool {
         self.0 & Self::LOCK != 0
     }
-    /// Ungate (enable) PLL output.
-    pub const fn ungate_pll_output(self) -> Self {
+    /// Unmask (enable) PLL output.
+    pub const fn unmask_pll_output(self) -> Self {
         Self(self.0 | Self::PLL_OUTPUT_GATE)
     }
-    /// Gate (disable) PLL output.
+    /// Mask (disable) PLL output.
     #[inline]
-    pub const fn gate_pll_output(self) -> Self {
+    pub const fn mask_pll_output(self) -> Self {
         Self(self.0 & !Self::PLL_OUTPUT_GATE)
     }
-    /// Get if PLL output is ungated.
+    /// Get if PLL output is unmasked.
     #[inline]
-    pub const fn is_pll_output_ungated(self) -> bool {
+    pub const fn is_pll_output_unmasked(self) -> bool {
         self.0 & Self::PLL_OUTPUT_GATE != 0
     }
     /// Get PLL N factor.
@@ -203,18 +203,18 @@ impl PllDdrControl {
     pub const fn is_locked(self) -> bool {
         self.0 & Self::LOCK != 0
     }
-    /// Ungate (enable) PLL output.
-    pub const fn ungate_pll_output(self) -> Self {
+    /// Unmask (enable) PLL output.
+    pub const fn unmask_pll_output(self) -> Self {
         Self(self.0 | Self::PLL_OUTPUT_GATE)
     }
-    /// Gate (disable) PLL output.
+    /// Mask (disable) PLL output.
     #[inline]
-    pub const fn gate_pll_output(self) -> Self {
+    pub const fn mask_pll_output(self) -> Self {
         Self(self.0 & !Self::PLL_OUTPUT_GATE)
     }
-    /// Get if PLL output is ungated.
+    /// Get if PLL output is unmasked.
     #[inline]
-    pub const fn is_pll_output_ungated(self) -> bool {
+    pub const fn is_pll_output_unmasked(self) -> bool {
         self.0 & Self::PLL_OUTPUT_GATE != 0
     }
     /// Get PLL N factor.
@@ -315,18 +315,18 @@ impl PllPeri0Control {
     pub const fn is_locked(self) -> bool {
         self.0 & Self::LOCK != 0
     }
-    /// Ungate (enable) PLL output.
-    pub const fn ungate_pll_output(self) -> Self {
+    /// Unmask (enable) PLL output.
+    pub const fn unmask_pll_output(self) -> Self {
         Self(self.0 | Self::PLL_OUTPUT_GATE)
     }
-    /// Gate (disable) PLL output.
+    /// Mask (disable) PLL output.
     #[inline]
-    pub const fn gate_pll_output(self) -> Self {
+    pub const fn mask_pll_output(self) -> Self {
         Self(self.0 & !Self::PLL_OUTPUT_GATE)
     }
-    /// Get if PLL output is ungated.
+    /// Get if PLL output is unmasked.
     #[inline]
-    pub const fn is_pll_output_ungated(self) -> bool {
+    pub const fn is_pll_output_unmasked(self) -> bool {
         self.0 & Self::PLL_OUTPUT_GATE != 0
     }
     /// Get PLL P1 factor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod com;
 #[macro_use]
 pub mod gpio;
 pub mod phy;
+pub mod smhc;
 pub mod spi;
 #[macro_use]
 pub mod uart;

--- a/src/smhc.rs
+++ b/src/smhc.rs
@@ -3,49 +3,43 @@ use volatile_register::RW;
 #[repr(C)]
 pub struct RegisterBlock {
     /// 0x00 - SMC Global Control Register.
-    pub gctrl: RW<u32>,
+    pub global_control: RW<u32>,
     /// 0x04 - SMC Clock Control Register.
-    pub clkcr: RW<u32>,
+    pub clock_control: RW<u32>,
     /// 0x08 - SMC Time Out Register.
     pub timeout: RW<u32>,
     /// 0x0C - SMC Bus Width Register.
     pub width: RW<u32>,
     /// 0x10 - SMC Block Size Register.
-    pub blksz: RW<u32>,
+    pub block_size: RW<u32>,
     /// 0x14 - SMC Byte Count Register.
-    pub bytecnt: RW<u32>,
+    pub byte_count: RW<u32>,
     /// 0x18 - SMC Command Register.
-    pub cmd: RW<u32>,
+    pub command: RW<u32>,
     /// 0x1C - SMC Argument Register.
-    pub arg: RW<u32>,
-    /// 0x20 - SMC Response Register 0.
-    pub resp0: RW<u32>,
-    /// 0x24 - SMC Response Register 1.
-    pub resp1: RW<u32>,
-    /// 0x28 - SMC Response Register 2.
-    pub resp2: RW<u32>,
-    /// 0x2C - SMC Response Register 3.
-    pub resp3: RW<u32>,
+    pub argument: RW<u32>,
+    /// 0x20 ..= 0x2C - SMC Response Registers 0..=3.
+    pub responses: [RW<u32>; 4],
     /// 0x8C - SMC IDMAC Interrupt Enable Register.
-    pub idie: RW<u32>,
+    pub interrupt_enable: RW<u32>,
     /// 0x38 - SMC Raw Interrupt Status Register.
-    pub rint: RW<u32>,
+    pub interrupt_state_raw: RW<u32>,
     /// 0x3C - SMC Status Register.
     pub status: RW<u32>,
     /// 0x40 - SMC FIFO Threshold Watermark Register.
-    pub ftrglevel: RW<u32>,
+    pub fifo_threshold: RW<u32>,
     /// 0x5c - SMC2 Newtiming Set Register.
     pub ntsr: RW<u32>,
     /// 0x80 - SMC IDMAC Control Register.
-    pub dmac: RW<u32>,
+    pub dma_control: RW<u32>,
     /// 0x84 - SMC IDMAC Descriptor List Base Address Register.
-    pub dlba: RW<u32>,
+    pub dma_descriptor_base: RW<u32>,
     /// 0x88 - SMC IDMAC Status Register.
-    pub idst: RW<u32>,
+    pub dma_state: RW<u32>,
     /// 0x140 - Drive Delay Control register.
-    pub drv_dl: RW<u32>,
+    pub drive_delay_control: RW<u32>,
     /// 0x184 - deskew control control register.
-    pub skew_ctrl: RW<u32>,
+    pub skew_control: RW<u32>,
     /// 0x200 - SMC FIFO Access Address.
     pub fifo: RW<u32>,
 }

--- a/src/smhc.rs
+++ b/src/smhc.rs
@@ -1,0 +1,51 @@
+use volatile_register::RW;
+
+#[repr(C)]
+pub struct RegisterBlock {
+    /// 0x00 - SMC Global Control Register.
+    pub gctrl: RW<u32>,
+    /// 0x04 - SMC Clock Control Register.
+    pub clkcr: RW<u32>,
+    /// 0x08 - SMC Time Out Register.
+    pub timeout: RW<u32>,
+    /// 0x0C - SMC Bus Width Register.
+    pub width: RW<u32>,
+    /// 0x10 - SMC Block Size Register.
+    pub blksz: RW<u32>,
+    /// 0x14 - SMC Byte Count Register.
+    pub bytecnt: RW<u32>,
+    /// 0x18 - SMC Command Register.
+    pub cmd: RW<u32>,
+    /// 0x1C - SMC Argument Register.
+    pub arg: RW<u32>,
+    /// 0x20 - SMC Response Register 0.
+    pub resp0: RW<u32>,
+    /// 0x24 - SMC Response Register 1.
+    pub resp1: RW<u32>,
+    /// 0x28 - SMC Response Register 2.
+    pub resp2: RW<u32>,
+    /// 0x2C - SMC Response Register 3.
+    pub resp3: RW<u32>,
+    /// 0x8C - SMC IDMAC Interrupt Enable Register.
+    pub idie: RW<u32>,
+    /// 0x38 - SMC Raw Interrupt Status Register.
+    pub rint: RW<u32>,
+    /// 0x3C - SMC Status Register.
+    pub status: RW<u32>,
+    /// 0x40 - SMC FIFO Threshold Watermark Register.
+    pub ftrglevel: RW<u32>,
+    /// 0x5c - SMC2 Newtiming Set Register.
+    pub ntsr: RW<u32>,
+    /// 0x80 - SMC IDMAC Control Register.
+    pub dmac: RW<u32>,
+    /// 0x84 - SMC IDMAC Descriptor List Base Address Register.
+    pub dlba: RW<u32>,
+    /// 0x88 - SMC IDMAC Status Register.
+    pub idst: RW<u32>,
+    /// 0x140 - Drive Delay Control register.
+    pub drv_dl: RW<u32>,
+    /// 0x184 - deskew control control register.
+    pub skew_ctrl: RW<u32>,
+    /// 0x200 - SMC FIFO Access Address.
+    pub fifo: RW<u32>,
+}

--- a/src/smhc.rs
+++ b/src/smhc.rs
@@ -1,15 +1,15 @@
-use volatile_register::RW;
+use volatile_register::{RO, RW};
 
 #[repr(C)]
 pub struct RegisterBlock {
     /// 0x00 - SMC Global Control Register.
-    pub global_control: RW<u32>,
+    pub global_control: RW<GlobalControl>,
     /// 0x04 - SMC Clock Control Register.
-    pub clock_control: RW<u32>,
+    pub clock_control: RW<ClockControl>,
     /// 0x08 - SMC Time Out Register.
     pub timeout: RW<u32>,
     /// 0x0C - SMC Bus Width Register.
-    pub width: RW<u32>,
+    pub bus_width: RW<u32>,
     /// 0x10 - SMC Block Size Register.
     pub block_size: RW<u32>,
     /// 0x14 - SMC Byte Count Register.
@@ -19,23 +19,27 @@ pub struct RegisterBlock {
     /// 0x1C - SMC Argument Register.
     pub argument: RW<u32>,
     /// 0x20 ..= 0x2C - SMC Response Registers 0..=3.
-    pub responses: [RW<u32>; 4],
-    /// 0x8C - SMC IDMAC Interrupt Enable Register.
-    pub interrupt_enable: RW<u32>,
+    pub responses: [RO<u32>; 4],
+    /// 0x30 - SMC Interrupt Mask Register.
+    pub interrupt_mask: RW<u32>,
+    /// 0x34 - SMC Masked Interrupt Status Register.
+    pub interrupt_state_masked: RO<u32>,
     /// 0x38 - SMC Raw Interrupt Status Register.
     pub interrupt_state_raw: RW<u32>,
     /// 0x3C - SMC Status Register.
-    pub status: RW<u32>,
+    pub status: RO<u32>,
     /// 0x40 - SMC FIFO Threshold Watermark Register.
     pub fifo_threshold: RW<u32>,
-    /// 0x5c - SMC2 Newtiming Set Register.
-    pub ntsr: RW<u32>,
+    /// 0x5c - SMC New Timing Set Register.
+    pub new_timing_set: RW<u32>,
     /// 0x80 - SMC IDMAC Control Register.
     pub dma_control: RW<u32>,
     /// 0x84 - SMC IDMAC Descriptor List Base Address Register.
     pub dma_descriptor_base: RW<u32>,
     /// 0x88 - SMC IDMAC Status Register.
     pub dma_state: RW<u32>,
+    /// 0x8C - SMC IDMAC Interrupt Enable Register.
+    pub dma_interrupt_enable: RW<u32>,
     /// 0x140 - Drive Delay Control register.
     pub drive_delay_control: RW<u32>,
     /// 0x184 - deskew control control register.
@@ -43,3 +47,137 @@ pub struct RegisterBlock {
     /// 0x200 - SMC FIFO Access Address.
     pub fifo: RW<u32>,
 }
+
+/// Global control register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct GlobalControl(u32);
+
+impl GlobalControl {
+    // TODO access_mode, set_access_mode, enum AccessMode { Dma, Ahb }
+    // TODO ddr_mode, set_ddr_mode, enum DdrMode { Sdr, Ddr }
+    // TODO is_dma_enabled, enable_dma, disable_dma
+    // TODO is_interrupt_enabled, enable_interrupt, disable_interrupt
+    // note: DMA_RST, FIFO_RST and SOFT_RST are write-1-set, auto-cleared by hardware
+    // TODO has_dma_reset (DMA_RST == 1), set_dma_reset (self.0 | DMA_RST)
+    // TODO has_fifo_reset, set_fifo_reset
+    // TODO has_software_reset, set_software_reset
+}
+
+/// Clock control register.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct ClockControl(u32);
+
+impl ClockControl {
+    // TODO is_mask_data0_enabled, enable_mask_data0, disable_mask_data0
+    // TODO is_card_clock_enabled, enable_card_clock, disable_card_clock
+    // TODO card_clock_divider, set_card_clock_divider (u8)
+}
+
+// TODO pub struct Timeout
+
+// TODO data_timeout_limit, set_data_timeout_limit (u32)
+
+// TODO pub struct BusWidth
+
+// TODO bus_width, set_bus_width, enum BusWidth { OneBit, FourBit, EightBit }
+
+// TODO pub struct BlockSize
+
+// TODO block_size, set_block_size (u16)
+
+// TODO pub struct ByteCount
+
+// TODO byte_count, set_byte_count (u32)
+
+// TODO pub struct Command
+
+// bit 31 (SMHC_CMD_START, or CMD_LOAD) is write-1-set by software, auto-cleared by hardware
+// TODO has_command_start, set_command_start
+// bit 21 (SMHC_CMD_UPCLK_ONLY or PRG_CLK)
+// TODO is_change_clock_enabled, enable_change_clock, disable_change_clock
+// bit 15 (SMHC_CMD_SEND_INIT_SEQUENCE or SEND_INIT_SEQ)
+// TODO is_init_sequence_enabled, enable_init_sequence, disable_init_sequence
+// bit 14 (SMHC_CMD_STOP_ABORT_CMD or STOP_ABT_CMD)
+// TODO is_stop_abort_enabled, enable_stop_abort, disable_stop_abort
+// bit 13 (SMHC_CMD_WAIT_PRE_OVER, WAIT_PRE_OVER)
+// TODO is_wait_for_complete_enabled, enable_wait_for_complete, disable_wait_for_complete
+// bit 12 (SMHC_CMD_SEND_AUTO_STOP, STOP_CMD_FLAG)
+// TODO is_auto_stop_enabled, enable_auto_stop, disable_auto_stop
+// bit 10 (SMHC_CMD_WRITE or TRANS_DIR)
+// TODO transfer_direction, set_transfer_direction, enum TransferDirection { Read, Write }
+// bit 9 (SMHC_CMD_DATA_EXPIRE or DATA_TRANS)
+// TODO is_data_transfer_enabled, enable_data_transfer, disable_data_transfer
+// bit 8 (SMHC_CMD_CHECK_RESPONSE_CRC, CHK_RESP_CRC)
+// TODO is_check_response_crc_enabled, enable_check_response_crc, disable_check_response_crc
+// bit 7 (SMHC_CMD_LONG_RESPONSE or LONG_RESP)
+// TODO is_long_response_enabled, enable_long_response, disable_long_response
+// bit 6 (SMHC_CMD_RESP_EXPIRE, or RESP_RCV)
+// TODO is_response_receive_enabled, enable_response_receive, disable_response_receive
+// bit 5:0 CMD_IDX
+// TODO command_index, set_command_index (u8)
+
+// TODO pub struct Argument
+
+// TODO argument, set_argument (u32)
+
+// TODO pub struct InterruptEnable
+
+// TODO is_interrupt_unmasked, mask_interrupt, unmask_interrupt (Interrupt)
+/* TODO pub enum Interrupt {
+    CardRemoved,
+    CardInserted,
+    Sdio,
+    DataEndBitError,
+    AutoCommandDone,
+    DataStartError,
+    CommandBusyAndIllegalWrite,
+    FifoUnderrunOrOverflow,
+    DataStarvationTimeout1V8SwitchDone,
+    DataTimeoutBootDataStart,
+    ResponseTimeoutBootAckReceived,
+    DataCrcError,
+    ResponseCrcError,
+    DataReceiveRequest,
+    DataTransmitRequest,
+    DataTransferComplete,
+    CommandComplete,
+    ResponseError
+} */
+
+// TODO pub struct InterruptStateMasked
+
+// TODO has_interrupt (Interrupt)
+
+// TODO pub struct InterruptStateRaw
+
+// TODO has_raw_interrupt (Interrupt)
+// TODO clear_interrupt (Interrupt) note: write 1 to clear
+
+// TODO pub struct Status
+
+// note: read-only register, no write functions
+// TODO fifo_level (u16)
+// TODO card_data_busy
+// TODO fifo_full
+// TODO fifo_empty
+
+// TODO pub struct FifoThreshold
+
+// TODO burst_size, set_burst_size, enum BurstSize { One, Four, Eight, Sixteen }
+// TODO receive_trigger_level, set_receive_trigger_level (u8)
+// TODO transmit_trigger_level, set_transmit_trigger_level (u8)
+
+// TODO pub struct NewTimingSet
+
+// 31 MODE_SELECT
+// TODO is_new_mode_enabled, enable_new_mode, disable_new_mode
+// 9:8 DAT_SAMPLE_TIMING_PHASE
+// TODO sample_timing_phase, set_sample_timing_phase, enum TimingPhase { Offset90, Offset180, Offset170, Offset0 }
+
+// TODO pub struct DriveDelay
+
+// TODO data_drive_phase, set_data_drive_phase (DrivePhase)
+// TODO command_drive_phase, set_command_drive_phase (DrivePhase)
+// TODO enum DrivePhase { Sdr90Ddr45, Sdr180Ddr90 }


### PR DESCRIPTION
This pull request adds registers, field access functions and corresponding test cases for the SMHC peripheral. It includes:

- introduce SMHC peripheral, add `RegisterBlock` structure.
- add SMHC register structures, field access functions and unit test cases for the following registers:
`global_control`, `clock_control`, `timeout`, `bus_width`, `block_size`,
`byte_count`, `command`, `argument`, `interrupt_mask`, `interrupt_state_masked`,
`interrupt_state_raw`, `status`, `fifo_water_level`, `new_timing_set`, `drive_delay_control`.

This PR is co-authored-by Yu Chongbing (@NanaHigh), ref: https://github.com/luojia65/allwinner-hal/pull/1 .