### PR TITLE
rt: build: update linker script to reflect correct SRAM size

### DIFF
--- a/allwinner-rt/build.rs
+++ b/allwinner-rt/build.rs
@@ -13,7 +13,7 @@ const LINKER_ALLWINNER_D1: &[u8] = b"
 OUTPUT_ARCH(riscv)
 ENTRY(head_jump)
 MEMORY {
-    SRAM : ORIGIN = 0x00020000, LENGTH = 32K
+    SRAM : ORIGIN = 0x00020000, LENGTH = 128K
 }
 SECTIONS {
     .head : {


### PR DESCRIPTION
- description:
  - change the SRAM length from `32K` to `128K`. this adjustment aligns with the specifications outlined in the memory mapping documentation
- reference:
  - Module      Address                      Size
  - SRAM A1     0x0002 0000---0x0002 7FFF    32KB
  - DSP0 IRAM   0x0002 8000---0x0003 7FFF    64KB (The local sram is switched to system boot)
  - DSP0 DRAM0  0x0003 8000---0x0003 FFFF    32KB (The local sram is switched to system boot)
  - DSP0 DRAM1  0x0004 0000---0x0004 7FFF    32KB (The local sram is switched to system boot)

![doc](https://github.com/user-attachments/assets/1bf240ff-421e-483c-8e52-09a7d0606bc4)
